### PR TITLE
[#33] 監視ファイルの追加、proxy設定のコメント追加

### DIFF
--- a/app/webpack.mix.js
+++ b/app/webpack.mix.js
@@ -12,12 +12,13 @@ const mix = require('laravel-mix');
  */
 
 mix.js('resources/js/app.js', 'public/js')
-    .postCss('resources/css/app.css', 'public/css', [
-        require('tailwindcss'),
-    ])
-    .browserSync({
-      proxy: "http://localhost:50080",
-      files: ['./resources/**/*', './public/**/*'],
-      open: true,
-      reloadOnRestart: true,
+  .postCss('resources/css/app.css', 'public/css', [
+    require('tailwindcss'),
+  ])
+  .browserSync({
+    // proxy: "http://localhost:50080", // Docker ホストから npx mix watch する場合
+    proxy: "web",  // コンテナ内から npx mix watch する場合はコンテナ名を指定する
+    files: ['./resources/**/*', './public/**/*', './app/**/*'],
+    open: true,
+    reloadOnRestart: true,
   });


### PR DESCRIPTION
#33

- `app`配下の`.php`ファイルの編集もホットリロード監視対象に加えました。
- `proxy`の設定を2パターン載せました
  - バインドマウントしたホストから`npm run`するケースは、`localhost:`+ウェブサーバーのポート名を指定する
  - `php`コンテナ内から`npm run`するケースは`docker`のサービス名を指定する