### PR TITLE
[#51] CircleCIのテストがパスしない理由の調査・対応

### DIFF
--- a/app/phpunit.xml.dist
+++ b/app/phpunit.xml.dist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory suffix="Test.php">./tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">./tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">./app</directory>
+        </include>
+    </coverage>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
+        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>


### PR DESCRIPTION
close #51

- [#51] add phpunit.xml.dist for circleci

## 原因

本来あるべきはずの設定ファイル`phpunit.xml`が欠けていた。
そのため、`SESSION_DRIVER`が、`null`を返していた。

その他にもいくつか`null`を返している項目があったので、ローカルで使用している`phpunit.xml`をコピーして`phpunit.xml.dist`を追加した。

## 補足

- `phpuni.mxl.dist`にした理由は、`phpunit.xml`は個人設定用なので`Git`で管理すべきではないため。(参考を参照)
- 設定自体は以下のいずれかで指定可能。
  - `.env.testing`
  - `phpunit.xml`
- CirclCIでの呼び出しは、以下になっているので、`phpunit.xml.dist`が自動で読み込まれる。

https://github.com/y-web21/port_lara_media/blob/45c2e9c3eaeabb46fe9505e44b88e8acdbacc95a/.circleci/config.yml#L83

## 参考

- [5. テストの構成 — PHPUnit latest Manual](https://phpunit.readthedocs.io/ja/latest/organizing-tests.html?highlight=phpunit.xml.dist#xml)
- [php - Is there any difference in naming the PHPunit configuration file phpunit.xml.dist or phpunit.xml - Stack Overflow](https://stackoverflow.com/questions/44764023/is-there-any-difference-in-naming-the-phpunit-configuration-file-phpunit-xml-dis)
